### PR TITLE
Update ecs.tf

### DIFF
--- a/modules/ecs-cluster/ecs.tf
+++ b/modules/ecs-cluster/ecs.tf
@@ -28,9 +28,7 @@ resource "aws_ecs_cluster" "cluster" {
 
 data "template_file" "ecs_init" {
   template = file("${path.module}/templates/ecs_init.tpl")
-  vars = {
-    cluster_name = var.cluster_name
-  }
+  cluster_name = var.cluster_name
 }
 
 #


### PR DESCRIPTION
Error: Unsupported block type

  on .terraform\modules\my-ecs\modules\ecs-cluster\ecs.tf line 31, in data "template_file" "ecs_init":
  31:     vars {

Blocks of type "vars" are not expected here. Did you mean to define argument
"vars"? If so, use the equals sign to assign it a value.