### PR TITLE
Add customizable healtcheck variables to the module `ecs-service`

### DIFF
--- a/modules/ecs-service/alb.tf
+++ b/modules/ecs-service/alb.tf
@@ -22,11 +22,11 @@ resource "aws_lb_target_group" "ecs-service" {
   target_type          = var.launch_type == "FARGATE" ? "ip" : "instance"
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = var.healthcheck_healthy_threshold
+    unhealthy_threshold = var.healthcheck_unhealthy_threshold
     protocol            = "HTTP"
     path                = var.healthcheck_path
-    interval            = 60
+    interval            = var.healthcheck_interval
     matcher             = var.healthcheck_matcher
   }
 }

--- a/modules/ecs-service/vars.tf
+++ b/modules/ecs-service/vars.tf
@@ -42,6 +42,19 @@ variable "deregistration_delay" {
 variable "healthcheck_matcher" {
   default = "200"
 }
+
+variable "healthcheck_interval" {
+  default = "60"
+}
+
+variable "healthcheck_healthy_threshold" {
+  default = "3"
+}
+
+variable "healthcheck_unhealthy_threshold" {
+  default = "3"
+}
+
 variable "healthcheck_path" {
   default = "/"
 }


### PR DESCRIPTION
Added three variables for customizing health check settings. Variables use defaults to maintain backward compatibility.

```terraform
variable "healthcheck_interval" {
  default = "60"
}

variable "healthcheck_healthy_threshold" {
  default = "3"
}

variable "healthcheck_unhealthy_threshold" {
  default = "3"
}
```