### PR TITLE
Ignore target group changes for blue green deployments in ECS

### DIFF
--- a/modules/ecs-service/ecs-service.tf
+++ b/modules/ecs-service/ecs-service.tf
@@ -127,6 +127,10 @@ resource "aws_ecs_service" "ecs-service" {
   }
 
   depends_on = [null_resource.alb_exists]
+
+  lifecycle {
+    ignore_changes = [load_balancer.target_group_arn]
+  }
 }
 
 

--- a/modules/ecs-service/ecs-service.tf
+++ b/modules/ecs-service/ecs-service.tf
@@ -129,7 +129,11 @@ resource "aws_ecs_service" "ecs-service" {
   depends_on = [null_resource.alb_exists]
 
   lifecycle {
-    ignore_changes = [load_balancer.target_group_arn]
+    ignore_changes = [
+      load_balancer,
+      desired_count,
+      task_definition,
+    ]
   }
 }
 


### PR DESCRIPTION
In blue-green deployments, target groups and task definitions are changed outside of terraform. 
Do it make sense to ignore changes?
``` 
      load_balancer,
      desired_count,
      task_definition,
```