### PR TITLE
Add defaults to ALB-Rule module

### DIFF
--- a/modules/alb-rule/vars.tf
+++ b/modules/alb-rule/vars.tf
@@ -8,10 +8,12 @@ variable "target_group_arn" {
 }
 
 variable "condition_field" {
+  default = ""
 }
 
 variable "condition_values" {
-  type = list(string)
+  default = []
+  type    = list(string)
 }
 
 variable "conditions" {


### PR DESCRIPTION
Add defaults to legacy vars to allow the use of `conditions` list alone

```
module "alb-rule-api-v1" {
  source       = "git@github.com:in4it/terraform-modules.git//modules/alb-rule"
  listener_arn = data.terraform_remote_state.shared.outputs.https-listener-arn

  priority         = 10
  target_group_arn = module.api.target_group_arn

  conditions = [
    {
      field  = "host-header"
      values = ["api.${var.domain}"]
    },
    {
      field  = "path-pattern"
      values = ["api/v1*"]
    }
  ]
}
```