### PR TITLE
Add RDS storage autoscaling

### DIFF
--- a/modules/rds/rds.tf
+++ b/modules/rds/rds.tf
@@ -6,6 +6,7 @@ resource "random_string" "password" {
 
 resource "aws_db_instance" "rds" {
   allocated_storage      = var.storage
+  max_allocated_storage  = var.max_allocated_storage
   engine                 = var.engine
   engine_version         = var.engine_version
   instance_class         = var.instance_type

--- a/modules/rds/vars.tf
+++ b/modules/rds/vars.tf
@@ -16,6 +16,10 @@ variable "storage" {
   description = "RDS storage in GB"
   default     = 100
 }
+variable "max_allocated_storage" {
+  description = "If greater than storage it will enable storage autoscaling"
+  default     = 0
+}
 variable "storage_type" {
   description = "RDS storage type"
   default     = "gp2"


### PR DESCRIPTION
The storage autoscaling feature was missing. With the `0` default value, already created dbs without storage autoscaling are not changed.