### PR TITLE
Add drop_invalid_header_fields to ALB

### DIFF
--- a/modules/alb/lb.tf
+++ b/modules/alb/lb.tf
@@ -10,6 +10,8 @@ resource "aws_lb" "lb" {
   idle_timeout               = var.idle_timeout
   enable_deletion_protection = false
 
+  drop_invalid_header_fields = var.drop_invalid_header_fields
+
   dynamic "access_logs" {
     for_each = length(keys(var.access_logs)) == 0 ? [] : [var.access_logs]
     content {

--- a/modules/alb/vars.tf
+++ b/modules/alb/vars.tf
@@ -42,8 +42,8 @@ variable "access_logs" {
 variable "tcp_ingress" {
   type = map(list(string))
   default = {
-    "80" = [ "0.0.0.0/0" ]
-    "443" = [ "0.0.0.0/0" ]
+    "80"  = ["0.0.0.0/0"]
+    "443" = ["0.0.0.0/0"]
   }
 }
 
@@ -55,4 +55,9 @@ variable "allow_additional_sg" {
     protocol        = string
   }))
   default = {}
+}
+
+variable "drop_invalid_header_fields" {
+  type    = bool
+  default = false
 }


### PR DESCRIPTION
routing.http.drop_invalid_header_fields.enabled

Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true), or routed to targets (false). The default is false. Elastic Load Balancing requires that valid HTTP header names conform to the regular expression [-A-Za-z0-9]+, as described in the HTTP Field Name Registry. Each name consists of alphanumeric characters or hyphens. Select true if you want HTTP headers that do not conform to this pattern, to be removed from requests.