### PR TITLE
Add OIDC-Github module

### DIFF
--- a/modules/oidc-github/README.md
+++ b/modules/oidc-github/README.md
@@ -1,0 +1,32 @@
+<!-- BEGIN_TF_DOCS -->
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_role.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| create\_oidc\_provider | Flag to enable/disable the creation of the GitHub OIDC provider. | `bool` | `true` | no |
+| enabled | Flag to enable/disable the creation of resources. | `bool` | `true` | no |
+| github\_repositories | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | n/a | yes |
+| iam\_role\_inline\_policies | Inline policies map with policy name as key and json as value. | `map(string)` | `{}` | no |
+| iam\_role\_name | Name of the IAM role to be created. This will be assumable by GitHub. | `string` | `"github"` | no |
+| iam\_role\_policy\_arns | List of IAM policy ARNs to attach to the IAM role. | `list(string)` | `[]` | no |
+| max\_session\_duration | Maximum session duration in seconds. | `number` | `3600` | no |
+| tags | Map of tags to be applied to all resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| iam\_role\_arn | ARN of the IAM role. |
+<!-- END_TF_DOCS -->

--- a/modules/oidc-github/data.tf
+++ b/modules/oidc-github/data.tf
@@ -1,0 +1,42 @@
+data "aws_partition" "current" {}
+
+data "aws_iam_policy_document" "assume_role" {
+  count = var.enabled ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test = "StringLike"
+      values = [
+        for repo in var.github_repositories :
+        "repo:%{if length(regexall(":+", repo)) > 0}${repo}%{else}${repo}:*%{endif}"
+      ]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+
+    principals {
+      identifiers = [local.oidc_provider_arn]
+      type        = "Federated"
+    }
+  }
+
+  version = "2012-10-17"
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = var.enabled && !var.create_oidc_provider ? 1 : 0
+
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}

--- a/modules/oidc-github/main.tf
+++ b/modules/oidc-github/main.tf
@@ -1,0 +1,44 @@
+locals {
+  github_organizations = toset([for repo in var.github_repositories : split("/", repo)[0]])
+  oidc_provider_arn    = var.enabled ? (var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn) : ""
+  partition            = data.aws_partition.current.partition
+}
+
+resource "aws_iam_role" "github" {
+  count = var.enabled ? 1 : 0
+
+  assume_role_policy    = data.aws_iam_policy_document.assume_role[0].json
+  description           = "Role assumed by the GitHub OIDC provider."
+  max_session_duration  = var.max_session_duration
+  name                  = var.iam_role_name
+  tags                  = var.tags
+
+  dynamic "inline_policy" {
+    for_each = var.iam_role_inline_policies
+
+    content {
+      name   = inline_policy.key
+      policy = inline_policy.value
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "custom" {
+  count = var.enabled ? length(var.iam_role_policy_arns) : 0
+
+  policy_arn = var.iam_role_policy_arns[count.index]
+  role       = aws_iam_role.github[0].id
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.enabled && var.create_oidc_provider ? 1 : 0
+
+  client_id_list = concat(
+    [for org in local.github_organizations : "https://github.com/${org}"],
+    ["sts.amazonaws.com"]
+  )
+
+  tags = var.tags
+  url  = "https://token.actions.githubusercontent.com"
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+}

--- a/modules/oidc-github/outputs.tf
+++ b/modules/oidc-github/outputs.tf
@@ -1,0 +1,5 @@
+output "iam_role_arn" {
+  depends_on  = [aws_iam_role.github]
+  description = "ARN of the IAM role."
+  value       = var.enabled ? aws_iam_role.github[0].arn : ""
+}

--- a/modules/oidc-github/variables.tf
+++ b/modules/oidc-github/variables.tf
@@ -1,0 +1,59 @@
+variable "create_oidc_provider" {
+  default     = true
+  description = "Flag to enable/disable the creation of the GitHub OIDC provider."
+  type        = bool
+}
+
+variable "enabled" {
+  default     = true
+  description = "Flag to enable/disable the creation of resources."
+  type        = bool
+}
+
+variable "github_repositories" {
+  description = "List of GitHub organization/repository names authorized to assume the role."
+  type        = list(string)
+
+  validation {
+    condition = length([
+      for repo in var.github_repositories : 1
+      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+[*]?|\\*)$", repo)) > 0
+    ]) == length(var.github_repositories)
+    error_message = "Repositories must be specified in the organization/repository format."
+  }
+}
+
+variable "iam_role_name" {
+  default     = "github"
+  description = "Name of the IAM role to be created. This will be assumable by GitHub."
+  type        = string
+}
+
+variable "iam_role_policy_arns" {
+  default     = []
+  description = "List of IAM policy ARNs to attach to the IAM role."
+  type        = list(string)
+}
+
+variable "iam_role_inline_policies" {
+  default     = {}
+  description = "Inline policies map with policy name as key and json as value."
+  type        = map(string)
+}
+
+variable "max_session_duration" {
+  default     = 3600
+  description = "Maximum session duration in seconds."
+  type        = number
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "Maximum session duration must be between 3600 and 43200 seconds."
+  }
+}
+
+variable "tags" {
+  default     = {}
+  description = "Map of tags to be applied to all resources."
+  type        = map(string)
+}

--- a/modules/oidc-github/versions.tf
+++ b/modules/oidc-github/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0"
+    }
+  }
+
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
### /oidc-github
Terraform module to configure GitHub Actions as an IAM OIDC identity provider in AWS. 
