### PR TITLE
Logs to s3 export

### DIFF
--- a/modules/log-s3-export/README.md
+++ b/modules/log-s3-export/README.md
@@ -1,0 +1,56 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.once_a_day](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.lambda_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_policy.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_triggering_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_s3_bucket.logs_retention_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [archive_file.lambda_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_iam_policy_document.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.log_exporter_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_archive_class"></a> [archive\_class](#input\_archive\_class) | n/a | `string` | `"GLACIER"` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | n/a | `string` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | n/a | `string` | n/a | yes |
+| <a name="input_days_to_archive"></a> [days\_to\_archive](#input\_days\_to\_archive) | Number of days to keep logs in S3 before moving to Glacier | `number` | `180` | no |
+| <a name="input_days_to_expire"></a> [days\_to\_expire](#input\_days\_to\_expire) | Number of days to keep logs in S3 before expiring/deleting | `number` | `365` | no |
+| <a name="input_export_days_before"></a> [export\_days\_before](#input\_export\_days\_before) | Number of days to export logs from | `number` | `1` | no |
+| <a name="input_log_groups_list"></a> [log\_groups\_list](#input\_log\_groups\_list) | n/a | `list(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | n/a |
+| <a name="output_lambda_arn"></a> [lambda\_arn](#output\_lambda\_arn) | n/a |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | n/a |

--- a/modules/log-s3-export/main.tf
+++ b/modules/log-s3-export/main.tf
@@ -1,0 +1,190 @@
+resource "random_string" "suffix" {
+  length  = 5
+  upper   = false
+  lower   = true
+  numeric = false
+  special = false
+}
+
+# Event trigger once a day
+resource "aws_cloudwatch_event_rule" "once_a_day" {
+  name                = "${var.name}-log-retention-run-lambda-${random_string.suffix.result}"
+  description         = "Trigger lambda function that grabs yesterdays Cloudwatch logs and sends them to an S3 bucket with CreateExportTask"
+  schedule_expression = "cron(1 0 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "lambda_target" {
+  rule      = aws_cloudwatch_event_rule.once_a_day.name
+  target_id = "${var.name}-ExportLogsLambdaTarget-${random_string.suffix.result}"
+  arn       = aws_lambda_function.log_exporter.arn
+}
+
+resource "aws_lambda_permission" "allow_triggering_function" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.log_exporter.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.once_a_day.arn
+}
+
+# Lambda function
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/src/lambda/"
+  output_path = "${path.module}/src/tmp/lambda.zip"
+}
+
+resource "aws_lambda_function" "log_exporter" {
+  function_name    = "${var.name}-ExportLogsLambda-${random_string.suffix.result}"
+  role             = aws_iam_role.log_exporter.arn
+  handler          = "index.handler"
+  filename         = "${path.module}/src/tmp/lambda.zip"
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  runtime          = "nodejs16.x"
+  timeout          = 300
+
+  environment {
+    variables = {
+      EXPORT_BUCKET = aws_s3_bucket.logs_retention_bucket.bucket
+      LOG_GROUPS    = jsonencode(var.log_groups_list)
+      BUCKET_PREFIX = var.bucket_prefix
+      DAYS_BEFORE   = var.export_days_before
+      RETRY         = 5
+    }
+  }
+  tracing_config {
+    mode = "Active"
+  }
+}
+
+# IAM for lambda function
+resource "aws_iam_role" "log_exporter" {
+  name               = "${var.name}-log-s3-retention-exporter-${random_string.suffix.result}"
+  assume_role_policy = data.aws_iam_policy_document.log_exporter_sts.json
+}
+
+data "aws_iam_policy_document" "log_exporter_sts" {
+
+  statement {
+    sid = "UseByLambda"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "log_exporter" {
+
+  statement {
+    sid = "LogsAccess"
+    actions = [
+      "logs:CreateExportTask",
+      "logs:Describe*",
+      "logs:ListTagsLogGroup",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "S3BucketAccess"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutBucketAcl",
+      "s3:GetBucketAcl"
+    ]
+    resources = ["${aws_s3_bucket.logs_retention_bucket.arn}/*"]
+  }
+  depends_on = [
+    aws_s3_bucket.logs_retention_bucket
+  ]
+}
+
+resource "aws_iam_policy" "log_exporter" {
+  name   = "${var.name}-log-exporter-policy-${random_string.suffix.result}"
+  policy = data.aws_iam_policy_document.log_exporter.json
+}
+
+resource "aws_iam_role_policy_attachment" "log_exporter" {
+  role       = aws_iam_role.log_exporter.name
+  policy_arn = aws_iam_policy.log_exporter.arn
+}
+
+# S3 bucket
+resource "aws_s3_bucket" "logs_retention_bucket" {
+  bucket = "${lower(var.name)}-logs-retention-${random_string.suffix.result}"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "s3" {
+  bucket = aws_s3_bucket.logs_retention_bucket.id
+
+  rule {
+    id     = "logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "${var.bucket_prefix}/"
+    }
+
+    transition {
+      days          = var.days_to_archive
+      storage_class = var.archive_class
+    }
+
+    expiration {
+      days = var.days_to_expire
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "s3" {
+  bucket = aws_s3_bucket.logs_retention_bucket.id
+  policy = data.aws_iam_policy_document.s3.json
+}
+
+data "aws_iam_policy_document" "s3" {
+
+  statement {
+    sid       = "GetBucketACL"
+    actions   = ["s3:GetBucketAcl", "s3:PutBucketAcl"]
+    resources = [aws_s3_bucket.logs_retention_bucket.arn]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.aws_region}.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid       = "PutObject"
+    actions   = ["s3:PutObject", "s3:PutObjectAcl"]
+    resources = ["${aws_s3_bucket.logs_retention_bucket.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.aws_region}.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+
+      values = [
+        "bucket-owner-full-control"
+      ]
+    }
+  }
+}

--- a/modules/log-s3-export/outputs.tf
+++ b/modules/log-s3-export/outputs.tf
@@ -1,0 +1,11 @@
+output "bucket_arn" {
+  value = aws_s3_bucket.logs_retention_bucket.arn
+}
+
+output "lambda_arn" {
+  value = aws_lambda_function.log_exporter.arn
+}
+
+output "lambda_role_arn" {
+  value = aws_iam_role.log_exporter.arn
+}

--- a/modules/log-s3-export/src/lambda/functions.js
+++ b/modules/log-s3-export/src/lambda/functions.js
@@ -1,0 +1,35 @@
+const pad = (num) => {
+    return String(num).padStart(2, '0')
+}
+
+const sleep = (sec) => {
+    return new Promise(resolve => setTimeout(resolve, sec));
+}
+
+const getExportStatus = async (taskId,cloudwatchlogs) => {
+    try {
+        const res = await cloudwatchlogs.describeExportTasks({ taskId: taskId }).promise();
+        return res.exportTasks[0].status.code;
+    } catch (error) {
+        const err = `[X] ERROR describing task ${taskId}::: ${error}`;
+        throw new Error(err);
+    }
+}
+const calcPrefix = (prefix, name, day) => {
+    return `${prefix}/${name}/${day.getUTCFullYear()}/${pad(day.getUTCMonth() + 1)}/${pad(day.getUTCDate())}/exportedlogs`
+}
+
+const checkEnvs = (list) => {
+    for (const val of list) {
+        if (typeof process.env[val] == 'undefined' || process.env[val] === null || (typeof process.env[val] == 'string' && !process.env[val].trim())) {
+            throw new Error(`${val} Environment Value is not defined!`);
+        }
+    }
+}
+module.exports = {
+    pad,
+    sleep,
+    getExportStatus,
+    calcPrefix,
+    checkEnvs
+}

--- a/modules/log-s3-export/src/lambda/index.js
+++ b/modules/log-s3-export/src/lambda/index.js
@@ -1,0 +1,77 @@
+const AWS = require("aws-sdk");
+const cwLogs = new AWS.CloudWatchLogs();
+const {
+  sleep,
+  getExportStatus,
+  calcPrefix,
+  checkEnvs,
+} = require("./functions");
+
+exports.handler = async function (event, context) {
+  //Get env variables
+  checkEnvs(["EXPORT_BUCKET", "LOG_GROUPS", "BUCKET_PREFIX"]);
+
+  const EXPORT_BUCKET = process.env.EXPORT_BUCKET;
+  const LOG_GROUPS = JSON.parse(process.env.LOG_GROUPS);
+  const BUCKET_PREFIX = process.env.BUCKET_PREFIX;
+  const DAYS_BEFORE = process.env.DAYS_BEFORE || 1;
+  const RETRY = process.env.RETRY || 5;
+
+  const results = {
+    success: [],
+    failed: [],
+    timeout: [],
+  };
+
+  //Set date objects
+  var today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  var fromDate = new Date(today);
+  fromDate.setDate(today.getDate() - DAYS_BEFORE);
+
+  //For each log group create export task
+  for (const logGroup of LOG_GROUPS) {
+    const parsedName = logGroup.replace(/\//g, ".");
+    const prefix = calcPrefix(BUCKET_PREFIX, parsedName, today);
+
+    const params = {
+      destination: EXPORT_BUCKET, // required
+      from: +fromDate, // required
+      logGroupName: logGroup, // required
+      to: +today, // required
+      destinationPrefix: prefix,
+      taskName: `export-${parsedName}`,
+    };
+
+    try {
+      const res = await cwLogs.createExportTask(params).promise();
+      console.log(`> Created exported task for ${logGroup}`);
+
+      // Status checking, with 5 time retry
+      for (let i = 0; i < RETRY; i++) {
+        // Wait some seconds for it to complete
+        await sleep(5000);
+
+        console.log(`> Checking Status.. try No.${i}`);
+        let currentStatus = await getExportStatus(res.taskId, cwLogs);
+        console.log(currentStatus);
+
+        if (["FAILED", "CANCELLED"].includes(currentStatus)) {
+          throw new Error("Export status is FAILED or CANCELLED");
+        }
+        if (currentStatus == "COMPLETED") {
+          results.success.push(logGroup);
+          break;
+        }
+        if (i == retry - 1) {
+          results.timeout.push(logGroup);
+        }
+      }
+    } catch (error) {
+      console.log(`[X] ERROR exporting task ${logGroup}`, error);
+      results.failed.push(logGroup);
+    }
+  }
+  console.log("> Lambda Task Completed: ", results);
+  return results;
+};

--- a/modules/log-s3-export/variables.tf
+++ b/modules/log-s3-export/variables.tf
@@ -1,0 +1,39 @@
+variable "name" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "log_groups_list" {
+  type = list(string)
+}
+
+variable "bucket_prefix" {
+  type = string
+  validation {
+    condition     = substr(var.bucket_prefix, -1, 1) != "/" && substr(var.bucket_prefix, 0, 1) != "/"
+    error_message = "The bucket_prefix must not end or begin with a '/'."
+  }
+}
+variable "archive_class" {
+  type    = string
+  default = "GLACIER"
+}
+variable "export_days_before" {
+  type        = number
+  description = "Number of days to export logs from"
+  default     = 1
+}
+variable "days_to_archive" {
+  type        = number
+  default     = 180
+  description = "Number of days to keep logs in S3 before moving to Glacier"
+}
+variable "days_to_expire" {
+  type        = number
+  default     = 365
+  description = "Number of days to keep logs in S3 before expiring/deleting"
+}
+


### PR DESCRIPTION
Created a new module for Cloudwatch --> S3 --> Archive--> Retention.

Uses a lambda to export logs and save to s3 with **createExportTask**
It takes as an input the log groups and for each one creates the export task alongside with the lifecycle parameters.

Can be used with together with Cloudwatch Logs retention to save costs.


![CloudwatchRetention drawio](https://github.com/in4it/terraform-modules/assets/53100368/7a72f6d9-c232-441f-96f0-cf365429ef02)
