### PR TITLE
Cloudfront/S3: Add funcionality for multiple distributions s3 combinations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.terraform

--- a/modules/cloudfront/README.md
+++ b/modules/cloudfront/README.md
@@ -6,7 +6,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 
 ## Modules
 
@@ -24,11 +24,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aliases"></a> [aliases](#input\_aliases) | List of aliases for the CloudFront distribution | `list(string)` | `[]` | no |
+| <a name="input_custom_error_responses"></a> [custom\_error\_responses](#input\_custom\_error\_responses) | The custom error response configuration for this distribution | <pre>list(object({<br>    error_code         = number<br>    response_code      = number<br>    response_page_path = string<br>  }))</pre> | `null` | no |
+| <a name="input_default_cache_behavior"></a> [default\_cache\_behavior](#input\_default\_cache\_behavior) | n/a | <pre>object({<br>    target_origin_id           = string<br>    allowed_methods            = optional(list(string))<br>    cached_methods             = optional(list(string))<br>    viewer_protocol_policy     = optional(string)<br>    compress                   = optional(bool)<br>    cache_policy_id            = optional(string)<br>    response_headers_policy_id = optional(string)<br>    origin_request_policy_id   = optional(string)<br>    min_ttl                    = optional(number)<br>    default_ttl                = optional(number)<br>    max_ttl                    = optional(number)<br>    function_associations = optional(list(object({<br>      event_type   = string<br>      function_arn = string<br>    })))<br>    forwarded_values = optional(object({<br>      query_string = bool<br>      cookies = object({<br>        forward = string<br>      })<br>      headers = optional(list(string))<br>    }))<br>  })</pre> | <pre>{<br>  "allowed_methods": [<br>    "GET",<br>    "HEAD",<br>    "OPTIONS"<br>  ],<br>  "cached_methods": [<br>    "GET",<br>    "HEAD"<br>  ],<br>  "target_origin_id": "test",<br>  "viewer_protocol_policy": "redirect-to-https"<br>}</pre> | no |
 | <a name="input_default_root_object"></a> [default\_root\_object](#input\_default\_root\_object) | Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL. | `string` | `null` | no |
-| <a name="input_function_associations"></a> [function\_associations](#input\_function\_associations) | Function associations for the CloudFront distribution | <pre>list(object({<br>    event_type   = string<br>    function_arn = string<br>  }))</pre> | `[]` | no |
+| <a name="input_geo_restriction"></a> [geo\_restriction](#input\_geo\_restriction) | The restriction configuration for this distribution | <pre>object({<br>    restriction_type = string<br>    locations        = optional(list(string))<br>  })</pre> | <pre>{<br>  "restriction_type": "none"<br>}</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `any` | n/a | yes |
-| <a name="input_s3_origins"></a> [s3\_origins](#input\_s3\_origins) | n/a | <pre>list(object({<br>    domain_name = string<br>    origin_id   = string<br>  }))</pre> | `[]` | no |
-| <a name="input_target_origin_id"></a> [target\_origin\_id](#input\_target\_origin\_id) | n/a | `any` | n/a | yes |
+| <a name="input_ordered_cache_behaviors"></a> [ordered\_cache\_behaviors](#input\_ordered\_cache\_behaviors) | n/a | <pre>list(object({<br>    path_pattern               = string<br>    target_origin_id           = string<br>    allowed_methods            = optional(list(string))<br>    cached_methods             = optional(list(string))<br>    viewer_protocol_policy     = optional(string)<br>    compress                   = optional(bool)<br>    cache_policy_id            = optional(string)<br>    response_headers_policy_id = optional(string)<br>    origin_request_policy_id   = optional(string)<br>    min_ttl                    = optional(number)<br>    default_ttl                = optional(number)<br>    max_ttl                    = optional(number)<br>    function_associations = optional(list(object({<br>      event_type   = string<br>      function_arn = string<br>    })))<br>    forwarded_values = optional(object({<br>      query_string = bool<br>      cookies = object({<br>        forward = string<br>      })<br>      headers = optional(list(string))<br>    }))<br>  }))</pre> | `null` | no |
+| <a name="input_s3_origins"></a> [s3\_origins](#input\_s3\_origins) | n/a | <pre>list(object({<br>    domain_name = string<br>    origin_id   = string<br>    origin_path = optional(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_viewer_certificate"></a> [viewer\_certificate](#input\_viewer\_certificate) | The SSL configuration for this distribution | <pre>object({<br>    acm_certificate_arn            = optional(string)<br>    cloudfront_default_certificate = optional(bool)<br>    iam_certificate_id             = optional(string)<br>    minimum_protocol_version       = optional(string)<br>    ssl_support_method             = optional(string)<br>  })</pre> | <pre>{<br>  "cloudfront_default_certificate": true<br>}</pre> | no |
 
 ## Outputs

--- a/modules/cloudfront/cloudfront.tf
+++ b/modules/cloudfront/cloudfront.tf
@@ -8,28 +8,51 @@ resource "aws_cloudfront_distribution" "this" {
   default_root_object = var.default_root_object
 
   default_cache_behavior {
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
-    target_origin_id       = var.target_origin_id
-    viewer_protocol_policy = "redirect-to-https"
-    compress               = true
+    target_origin_id           = var.default_cache_behavior.target_origin_id
+    allowed_methods            = lookup(var.default_cache_behavior, "allowed_methods", ["GET", "HEAD", "OPTIONS"])
+    cached_methods             = lookup(var.default_cache_behavior, "cached_methods", ["GET", "HEAD"])
+    viewer_protocol_policy     = lookup(var.default_cache_behavior, "viewer_protocol_policy", "redirect-to-https")
+    compress                   = lookup(var.default_cache_behavior, "compress", true)
+    cache_policy_id            = lookup(var.default_cache_behavior, "cache_policy_id", "658327ea-f89d-4fab-a63d-7e88639e58f6")
+    response_headers_policy_id = lookup(var.default_cache_behavior, "response_headers_policy_id", null)
+    origin_request_policy_id   = lookup(var.default_cache_behavior, "origin_request_policy_id", null)
+    min_ttl                    = lookup(var.default_cache_behavior, "min_ttl", null)
+    default_ttl                = lookup(var.default_cache_behavior, "default_ttl", null)
+    max_ttl                    = lookup(var.default_cache_behavior, "max_ttl", null)
 
-    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
 
     dynamic "function_association" {
-      for_each = toset(var.function_associations)
+      for_each = var.default_cache_behavior["function_associations"] != null ? var.default_cache_behavior["function_associations"] : []
+      iterator = function_association
       content {
         event_type   = function_association.value.event_type
         function_arn = function_association.value.function_arn
+      }
+    }
+
+    dynamic "forwarded_values" {
+      for_each = var.default_cache_behavior["forwarded_values"] != null ? [var.default_cache_behavior["forwarded_values"]] : []
+
+      iterator = forwarded_values
+
+      content {
+        query_string = forwarded_values.value.query_string
+        cookies {
+          forward = forwarded_values.value.cookies.forward
+        }
+        headers                 = lookup(forwarded_values.value, "headers", [])
+        query_string_cache_keys = lookup(forwarded_values.value, "query_string_cache_keys", [])
       }
     }
   }
 
   dynamic "origin" {
     for_each = { for origins in var.s3_origins : origins.domain_name => origins }
+    iterator = origin
     content {
       domain_name = origin.value.domain_name
       origin_id   = origin.value.origin_id
+      origin_path = lookup(origin.value, "origin_path", null)
 
       s3_origin_config {
         origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
@@ -37,9 +60,50 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
+  dynamic "ordered_cache_behavior" {
+    for_each = var.ordered_cache_behaviors != null ? var.ordered_cache_behaviors : []
+    iterator = ordered_cache_behavior
+    content {
+      path_pattern               = ordered_cache_behavior.value.path_pattern
+      target_origin_id           = ordered_cache_behavior.value.target_origin_id
+      allowed_methods            = lookup(ordered_cache_behavior.value, "allowed_methods", var.default_cache_behavior.allowed_methods)
+      cached_methods             = lookup(ordered_cache_behavior.value, "cached_methods", var.default_cache_behavior.cached_methods)
+      viewer_protocol_policy     = lookup(ordered_cache_behavior.value, "viewer_protocol_policy", var.default_cache_behavior.viewer_protocol_policy)
+      compress                   = lookup(ordered_cache_behavior.value, "compress", var.default_cache_behavior.compress)
+      cache_policy_id            = lookup(ordered_cache_behavior.value, "cache_policy_id", var.default_cache_behavior.cache_policy_id)
+      response_headers_policy_id = lookup(ordered_cache_behavior.value, "response_headers_policy_id", var.default_cache_behavior.response_headers_policy_id)
+      origin_request_policy_id   = lookup(ordered_cache_behavior.value, "origin_request_policy_id", var.default_cache_behavior.origin_request_policy_id)
+      min_ttl                    = lookup(ordered_cache_behavior.value, "min_ttl", null)
+      default_ttl                = lookup(ordered_cache_behavior.value, "default_ttl", null)
+      max_ttl                    = lookup(ordered_cache_behavior.value, "max_ttl", null)
+
+      dynamic "function_association" {
+        for_each = ordered_cache_behavior.value["function_associations"] != null ? ordered_cache_behavior.value["function_associations"] : []
+        iterator = function_association
+        content {
+          event_type   = function_association.value.event_type
+          function_arn = function_association.value.function_arn
+        }
+      }
+      dynamic "forwarded_values" {
+        for_each = ordered_cache_behavior.value["forwarded_values"] != null ? [ordered_cache_behavior.value["forwarded_values"]] : []
+        iterator = forwarded_values
+        content {
+          query_string = forwarded_values.value.query_string
+          cookies {
+            forward = forwarded_values.value.cookies.forward
+          }
+          headers                 = lookup(forwarded_values.value, "headers", [])
+          query_string_cache_keys = lookup(forwarded_values.value, "query_string_cache_keys", [])
+        }
+      }
+    }
+  }
+
   restrictions {
     geo_restriction {
-      restriction_type = "none"
+      restriction_type = var.geo_restriction.restriction_type
+      locations        = lookup(var.geo_restriction, "locations", null)
     }
   }
 
@@ -50,6 +114,16 @@ resource "aws_cloudfront_distribution" "this" {
 
     minimum_protocol_version = lookup(var.viewer_certificate, "minimum_protocol_version", "TLSv1")
     ssl_support_method       = lookup(var.viewer_certificate, "ssl_support_method", null)
+  }
+
+  dynamic "custom_error_response" {
+    for_each = var.custom_error_responses != null ? var.custom_error_responses : []
+    iterator = custom_error_response
+    content {
+      error_code         = custom_error_response.value.error_code
+      response_code      = lookup(custom_error_response.value, "response_code", 200)
+      response_page_path = lookup(custom_error_response.value, "response_page_path", "/index.html")
+    }
   }
 
   aliases = var.aliases

--- a/modules/cloudfront/variables.tf
+++ b/modules/cloudfront/variables.tf
@@ -1,14 +1,72 @@
 variable "name" {
 }
-variable "target_origin_id" {
-}
 
+variable "default_cache_behavior" {
+  type = object({
+    target_origin_id           = string
+    allowed_methods            = optional(list(string))
+    cached_methods             = optional(list(string))
+    viewer_protocol_policy     = optional(string)
+    compress                   = optional(bool)
+    cache_policy_id            = optional(string)
+    response_headers_policy_id = optional(string)
+    origin_request_policy_id   = optional(string)
+    min_ttl                    = optional(number)
+    default_ttl                = optional(number)
+    max_ttl                    = optional(number)
+    function_associations = optional(list(object({
+      event_type   = string
+      function_arn = string
+    })))
+    forwarded_values = optional(object({
+      query_string = bool
+      cookies = object({
+        forward = string
+      })
+      headers = optional(list(string))
+    }))
+  })
+  default = {
+    target_origin_id       = "test"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+  }
+}
+variable "ordered_cache_behaviors" {
+  type = list(object({
+    path_pattern               = string
+    target_origin_id           = string
+    allowed_methods            = optional(list(string))
+    cached_methods             = optional(list(string))
+    viewer_protocol_policy     = optional(string)
+    compress                   = optional(bool)
+    cache_policy_id            = optional(string)
+    response_headers_policy_id = optional(string)
+    origin_request_policy_id   = optional(string)
+    min_ttl                    = optional(number)
+    default_ttl                = optional(number)
+    max_ttl                    = optional(number)
+    function_associations = optional(list(object({
+      event_type   = string
+      function_arn = string
+    })))
+    forwarded_values = optional(object({
+      query_string = bool
+      cookies = object({
+        forward = string
+      })
+      headers = optional(list(string))
+    }))
+  }))
+  default = null
+}
 variable "s3_origins" {
   type = list(object({
     domain_name = string
     origin_id   = string
+    origin_path = optional(string)
   }))
-  default = []
 }
 variable "aliases" {
   description = "List of aliases for the CloudFront distribution"
@@ -33,11 +91,23 @@ variable "default_root_object" {
   type        = string
   default     = null
 }
-variable "function_associations" {
-  description = "Function associations for the CloudFront distribution"
+
+variable "geo_restriction" {
+  description = "The restriction configuration for this distribution"
+  type = object({
+    restriction_type = string
+    locations        = optional(list(string))
+  })
+  default = {
+    restriction_type = "none"
+  }
+}
+variable "custom_error_responses" {
+  description = "The custom error response configuration for this distribution"
   type = list(object({
-    event_type   = string
-    function_arn = string
+    error_code         = number
+    response_code      = number
+    response_page_path = string
   }))
-  default = []
+  default = null
 }

--- a/modules/s3/README.md
+++ b/modules/s3/README.md
@@ -6,7 +6,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 
 ## Modules
 
@@ -29,9 +29,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_policy_statements"></a> [additional\_policy\_statements](#input\_additional\_policy\_statements) | additional policy statements to add to the s3 bucket policy | <pre>list(object({<br>    sid = optional(string)<br>    principals = object({<br>      identifiers = list(string)<br>      type        = string<br>    })<br>    effect    = string<br>    actions   = list(string)<br>    resources = list(string)<br>    conditions = optional(list(object({<br>      test     = string<br>      values   = list(string)<br>      variable = string<br>    })))<br>  }))</pre> | `[]` | no |
-| <a name="input_cloudfront_allow_path"></a> [cloudfront\_allow\_path](#input\_cloudfront\_allow\_path) | S3 path to allow cloudfront access to. Default allows access to the entire bucket. | `string` | `""` | no |
-| <a name="input_cloudfront_origin_access_identity_arn"></a> [cloudfront\_origin\_access\_identity\_arn](#input\_cloudfront\_origin\_access\_identity\_arn) | CloudFront Origin Access ARN | `string` | `""` | no |
-| <a name="input_cloudfront_origin_access_identity_iam_actions"></a> [cloudfront\_origin\_access\_identity\_iam\_actions](#input\_cloudfront\_origin\_access\_identity\_iam\_actions) | iam actions to give cloudfront access to | `list(string)` | <pre>[<br>  "s3:Get*"<br>]</pre> | no |
+| <a name="input_cloudfront_origins"></a> [cloudfront\_origins](#input\_cloudfront\_origins) | List of cloudfront origins to allow access to the bucket. Example:<br>  [{<br>    oai\_arn         = string       # The ARN of the OAI to allow access to the bucket<br>    oai\_iam\_actions = list(string) # ["s3:GetObject*"]<br>    allow\_path      = string       # S3 path to allow cloudfront access to. Default allows access to the entire bucket.<br>  }] | <pre>list(object({<br>    oai_arn         = string       <br>    oai_iam_actions = list(string) <br>    allow_path      = string       <br>  }))</pre> | `[]` | no |
 | <a name="input_lifecycle_rules"></a> [lifecycle\_rules](#input\_lifecycle\_rules) | lifecycle rules to add to the bucket | <pre>list(object({<br>    id     = string<br>    status = string # "Enabled" or "Disabled"<br>    transition = optional(object({<br>      date          = optional(string)<br>      days          = optional(number)<br>      storage_class = string<br>    }))<br>    expiration = optional(object({<br>      days = number<br>    }))<br>    filter = optional(object({<br>      prefix                   = optional(string)<br>      object_size_less_than    = optional(number)<br>      object_size_greater_than = optional(number)<br>      and                      = optional(any)<br>      tag = optional(object({<br>        key   = string<br>        value = string<br>      }))<br>    }))<br>  }))</pre> | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | name of the s3 bucket | `any` | n/a | yes |
 | <a name="input_public_access_block"></a> [public\_access\_block](#input\_public\_access\_block) | values for the public access block | <pre>object({<br>    block_public_acls       = bool<br>    block_public_policy     = bool<br>    ignore_public_acls      = bool<br>    restrict_public_buckets = bool<br>  })</pre> | <pre>{<br>  "block_public_acls": true,<br>  "block_public_policy": true,<br>  "ignore_public_acls": true,<br>  "restrict_public_buckets": true<br>}</pre> | no |

--- a/modules/s3/s3.tf
+++ b/modules/s3/s3.tf
@@ -42,21 +42,21 @@ data "aws_iam_policy_document" "this" {
   policy_id = "s3-bucket-policy"
 
   dynamic "statement" {
-    for_each = var.cloudfront_origin_access_identity_arn == "" ? [] : [var.cloudfront_origin_access_identity_arn]
+    for_each = var.cloudfront_origins != null ? var.cloudfront_origins : []
     content {
-      sid = "PolicyForCouldFrontPrivateContent"
+      sid = "PolicyForCouldFrontPrivateContent${statement.key}"
       principals {
         identifiers = [
-          var.cloudfront_origin_access_identity_arn
+          statement.value.oai_arn
         ]
         type = "AWS"
       }
       effect  = "Allow"
-      actions = var.cloudfront_origin_access_identity_iam_actions
-      resources = var.cloudfront_allow_path == "" ? [
+      actions = statement.value.oai_iam_actions
+      resources = statement.value.allow_path == "" ? [
         "arn:aws:s3:::${aws_s3_bucket.this.id}",
         "arn:aws:s3:::${aws_s3_bucket.this.id}/*",
-      ] : ["${aws_s3_bucket.this.arn}/${var.cloudfront_allow_path}"]
+      ] : ["${aws_s3_bucket.this.arn}/${statement.value.allow_path}/*"]
     }
   }
   statement {

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -7,16 +7,23 @@ variable "versioning" {
   default     = true
 }
 
-variable "cloudfront_origin_access_identity_arn" {
-  description = "CloudFront Origin Access ARN"
-  default     = ""
+variable "cloudfront_origins" {
+  description = <<EOF
+  List of cloudfront origins to allow access to the bucket. Example:
+  [{
+    oai_arn         = string       # The ARN of the OAI to allow access to the bucket
+    oai_iam_actions = list(string) # ["s3:GetObject*"]
+    allow_path      = string       # S3 path to allow cloudfront access to. Default allows access to the entire bucket.
+  }]
+  EOF
+  type = list(object({
+    oai_arn         = string       
+    oai_iam_actions = list(string) 
+    allow_path      = string       
+  }))
+  default = []
 }
 
-variable "cloudfront_origin_access_identity_iam_actions" {
-  description = "iam actions to give cloudfront access to"
-  type        = list(string)
-  default     = ["s3:Get*"]
-}
 variable "additional_policy_statements" {
   description = "additional policy statements to add to the s3 bucket policy"
   type = list(object({
@@ -51,11 +58,7 @@ variable "public_access_block" {
     restrict_public_buckets = true
   }
 }
-variable "cloudfront_allow_path" {
-  description = "S3 path to allow cloudfront access to. Default allows access to the entire bucket."
-  type        = string
-  default     = ""
-}
+
 variable "lifecycle_rules" {
   description = "lifecycle rules to add to the bucket"
   type = list(object({


### PR DESCRIPTION
Added functionality needed for :
- Multiple Distributions pointing to a single S3
- Multiple behaviors into a distribution

Its not backwards compatible with previous version in relation to the structure of the variables but I kept the same default values as before. 

So we can easily update the modules just to the new variable structure and the terraform plans should not differ. 
