### PR TITLE
WAF/regex rules

### DIFF
--- a/modules/waf/vars.tf
+++ b/modules/waf/vars.tf
@@ -54,6 +54,5 @@ variable "regex_match_rules" {
     statement  = any
     rule_label = optional(list(string), null)
   }))
-  default = null
-
+  default = []
 }

--- a/modules/waf/vars.tf
+++ b/modules/waf/vars.tf
@@ -2,9 +2,18 @@ variable "name" {
   description = "name of WAF"
   default     = "alb-waf"
 }
+variable "scope" {
+  description = "scope of WAF, use 'CLOUDFRONT' for CloudFront distributions"
+  default     = "REGIONAL"
+  validation {
+    condition     = var.scope == "REGIONAL" || var.scope == "CLOUDFRONT"
+    error_message = "scope must be REGIONAL or CLOUDFRONT"
+  }
+}
 variable "lb_arns" {
-  type = set(string)
-  description = "ARN of ALBs"
+  type        = set(string)
+  description = "ARN of ALBs to associate with WAF"
+  default     = []
 }
 
 variable "env" {
@@ -36,4 +45,15 @@ variable "managed_rules" {
     counting_rules           = optional(list(string))
   }))
   default = []
+}
+variable "regex_match_rules" {
+  type = list(object({
+    name       = string
+    priority   = number
+    action     = string # "count" or "block"
+    statement  = any
+    rule_label = optional(list(string), null)
+  }))
+  default = null
+
 }

--- a/modules/waf/waf.tf
+++ b/modules/waf/waf.tf
@@ -103,7 +103,7 @@ resource "aws_wafv2_web_acl" "this" {
 
       visibility_config {
         cloudwatch_metrics_enabled = true
-        metric_name                = "ratelimit-${rule.value.name}"
+        metric_name                = "managedrules-${rule.value.name}"
         sampled_requests_enabled   = true
       }
     }
@@ -113,10 +113,9 @@ resource "aws_wafv2_web_acl" "this" {
     content {
       name     = rule.value.name
       priority = rule.value.priority
-
-      override_action {
-        dynamic "none" {
-          for_each = rule.value.action == "none" ? [1] : []
+      action {
+        dynamic "block" {
+          for_each = rule.value.action == "block" ? [1] : []
           content {
           }
         }
@@ -125,8 +124,8 @@ resource "aws_wafv2_web_acl" "this" {
           content {
           }
         }
-        dynamic "block" {
-          for_each = rule.value.action == "block" ? [1] : []
+        dynamic "allow" {
+          for_each = rule.value.action == "allow" ? [1] : []
           content {
           }
         }
@@ -179,17 +178,9 @@ resource "aws_wafv2_web_acl" "this" {
                 }
               }
             }
-            dynamic "text_transformation" {
-              for_each = lookup(rule.value.statement, "text_transformation", null) != null ? [
-                for rule in lookup(rule.value.statement, "text_transformation") : {
-                  priority = rule.priority
-                  type     = rule.type
-              }] : []
-
-              content {
-                priority = text_transformation.value.priority
-                type     = text_transformation.value.type
-              }
+            text_transformation {
+              priority = 0
+              type     = "NONE"
             }
           }
         }

--- a/modules/waf/waf.tf
+++ b/modules/waf/waf.tf
@@ -1,6 +1,6 @@
 resource "aws_wafv2_web_acl" "this" {
   name  = var.env == "" ? var.name : "${var.name}-${var.env}"
-  scope = "REGIONAL"
+  scope = var.scope
 
   default_action {
     allow {}
@@ -73,9 +73,9 @@ resource "aws_wafv2_web_acl" "this" {
           vendor_name = rule.value.managed_rule_vendor_name
           dynamic "rule_action_override" {
             for_each = merge(
-              { for r in coalesce(rule.value.blocking_rules,[]) : r => "block" },
-              { for r in coalesce(rule.value.allowing_rules,[]) : r => "allow" },
-              { for r in coalesce(rule.value.counting_rules,[]) : r => "count"}
+              { for r in coalesce(rule.value.blocking_rules, []) : r => "block" },
+              { for r in coalesce(rule.value.allowing_rules, []) : r => "allow" },
+              { for r in coalesce(rule.value.counting_rules, []) : r => "count" }
             )
             content {
               name = rule_action_override.key
@@ -104,6 +104,100 @@ resource "aws_wafv2_web_acl" "this" {
       visibility_config {
         cloudwatch_metrics_enabled = true
         metric_name                = "ratelimit-${rule.value.name}"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+  dynamic "rule" {
+    for_each = { for r in var.regex_match_rules : r.name => r }
+    content {
+      name     = rule.value.name
+      priority = rule.value.priority
+
+      override_action {
+        dynamic "none" {
+          for_each = rule.value.action == "none" ? [1] : []
+          content {
+          }
+        }
+        dynamic "count" {
+          for_each = rule.value.action == "count" ? [1] : []
+          content {
+          }
+        }
+        dynamic "block" {
+          for_each = rule.value.action == "block" ? [1] : []
+          content {
+          }
+        }
+      }
+      statement {
+        dynamic "regex_match_statement" {
+          for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
+
+          content {
+            regex_string = regex_match_statement.value.regex_string
+
+            dynamic "field_to_match" {
+              for_each = lookup(rule.value.statement, "field_to_match", null) != null ? [rule.value.statement.field_to_match] : []
+
+              content {
+                dynamic "all_query_arguments" {
+                  for_each = lookup(field_to_match.value, "all_query_arguments", null) != null ? [1] : []
+                  content {}
+                }
+                dynamic "body" {
+                  for_each = lookup(field_to_match.value, "body", null) != null ? [1] : []
+                  content {}
+                }
+                dynamic "method" {
+                  for_each = lookup(field_to_match.value, "method", null) != null ? [1] : []
+
+                  content {}
+                }
+                dynamic "query_string" {
+                  for_each = lookup(field_to_match.value, "query_string", null) != null ? [1] : []
+
+                  content {}
+                }
+                dynamic "single_header" {
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
+
+                  content {
+                    name = single_header.value.name
+                  }
+                }
+                dynamic "single_query_argument" {
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
+                  content {
+                    name = single_query_argument.value.name
+                  }
+                }
+                dynamic "uri_path" {
+                  for_each = lookup(field_to_match.value, "uri_path", null) != null ? [1] : []
+                  content {}
+                }
+              }
+            }
+            dynamic "text_transformation" {
+              for_each = lookup(rule.value.statement, "text_transformation", null) != null ? [
+                for rule in lookup(rule.value.statement, "text_transformation") : {
+                  priority = rule.priority
+                  type     = rule.type
+              }] : []
+
+              content {
+                priority = text_transformation.value.priority
+                type     = text_transformation.value.type
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "regex-${rule.value.name}"
         sampled_requests_enabled   = true
       }
     }


### PR DESCRIPTION
- [x] Add the ability of creating a Global WAF for use with Cloudfront, not only ALBs. (associations happen in the Cloudfront terraform resource as per the docs say)
- [x] Add `regex_match_statement` option to filter requests by any parameter.